### PR TITLE
* add feature: create template for study works in IB

### DIFF
--- a/latex/tex/docinfo.tex
+++ b/latex/tex/docinfo.tex
@@ -23,7 +23,8 @@
 \newcommand{\hsmazweitkorrektor}{Erika Mustermann, Paukenschlag GmbH} % Betreuer im Unternehmen oder Zweitkorrektor
 \newcommand{\hsmafakultaet}{I} % I für Informatik
 \newcommand{\hsmastudiengang}{IB} % IB IMB UIB IM MTB
-  
+\newcommand{\hsmastudienarbeit}{FALSE} % nur IB: TRUE für Studienarbeit, ansonsten FALSE
+
 % -------------------------------------------------------
 % Abstract
 

--- a/latex/tex/titelblatt.tex
+++ b/latex/tex/titelblatt.tex
@@ -9,11 +9,18 @@
   {\newcommand{\hsmafakultaetlangde}{Fakultät für Informatik}%
    \newcommand{\hsmafakultaetlangen}{Department of Computer Science}}{}
 
-\ifthenelse{\equal{\hsmastudiengang}{IB}}%
+\ifthenelse{\equal{\hsmastudiengang}{IB} \AND \equal{\hsmastudienarbeit}{FALSE}}%
   {\newcommand{\hsmastudienganglangde}{Informatik}%
   \newcommand{\hsmastudienganglangen}{Computer Science}%
   \newcommand{\hsmatypde}{Bachelor-Thesis}%
   \newcommand{\hsmatypen}{Bachelor Thesis}%
+  \newcommand{\hsmagrad}{\hsmabsc}}{}
+
+\ifthenelse{\equal{\hsmastudiengang}{IB} \AND \equal{\hsmastudienarbeit}{TRUE}}%
+  {\newcommand{\hsmastudienganglangde}{Informatik}%
+  \newcommand{\hsmastudienganglangen}{Computer Science}%
+  \newcommand{\hsmatypde}{Studienarbeit}%
+  \newcommand{\hsmatypen}{Study Work}%
   \newcommand{\hsmagrad}{\hsmabsc}}{}
 
 \ifthenelse{\equal{\hsmastudiengang}{IMB}}%
@@ -73,6 +80,9 @@
    \newcommand{\hsmafakultaetlang}{\hsmafakultaetlangen}%
    \selectlanguage{english}}%
 
+% Bei Studienarbeit keine Angabe des angestrebten Grades
+\ifthenelse{\equal{\hsmastudienarbeit}{TRUE} \AND \equal{\hsmastudiengang}{IB}}
+{\renewcommand{\hsmathesistype}{}}{}
 
 % Daten in die Standard Felder von KOMA-Script eintragen
 \titlehead{\hsmatyp im \  \hsmastudienganglang}


### PR DESCRIPTION
Add some if-else statements to create a template for study works.
As far as I know, study works do not have a description of the target degree,
which is simply removed by overwriting the \hsmathesistype command and leave it blank.
Also the name of the work is set as "Study Work" or "Studienarbeit".

A new command, \hsmastudienarbeit, is defined which can be set to the strings TRUE or FALSE to indicate if the template is for a study work or not.

Feature is only set for the IB course since I don't know the regulation in IMB, UIB etc.
So if the \hsmastudienarbeit command is set to TRUE but any other course than IB,
no effects take place.