### PR TITLE
Make the text of the rest of the document black again

### DIFF
--- a/latex/tex/titelblatt.tex
+++ b/latex/tex/titelblatt.tex
@@ -196,6 +196,7 @@ Diese Arbeit darf Dritten, mit Ausnahme der betreuenden Dozenten und befugten Mi
 Eine Vervielfältigung und Veröffentlichung der Arbeit ohne ausdrückliche Genehmigung -- auch in Auszügen -- ist nicht erlaubt.
 }{}
 
+\color{black}
 \cleardoublepage
 
 % Abstract


### PR DESCRIPTION
Make the text of the rest of the document black after the red "Sperrvermerk".