### PR TITLE
"ngerman" als babel Hauptsprache definiert

### DIFF
--- a/latex/tex/preambel.tex
+++ b/latex/tex/preambel.tex
@@ -17,7 +17,7 @@
 \usepackage[utf8]{inputenc}       % Dateien in UTF-8 benutzen
 \usepackage[T1]{fontenc}          % Zeichenkodierung
 \usepackage{graphicx}             % Bilder einbinden
-\usepackage[ngerman,english]{babel}       % Deutsch und Englisch unterstützen
+\usepackage[main=ngerman, english]{babel}       % Deutsch und Englisch unterstützen
 \usepackage{xcolor}               % Color support
 \usepackage{amsmath}              % Matheamtische Formeln
 \usepackage{amsfonts}             % Mathematische Zeichensätze


### PR DESCRIPTION
Nach http://ctan.mirrors.hoobly.com/macros/latex/required/babel/base/babel.pdf muss die Hauptsprache des Dokuments beim Einbinden von Babel an letzter Stelle stehen oder mit "main=" definiert werden. Aktuell ist damit "english" die Hauptsprache, obwohl die meisten Arbeiten mit diesem Template vermutlich in deutscher Sprache geschrieben werden.