### PR TITLE
\usepackage[backend=bibtex]{biblatex}

### DIFF
--- a/latex/tex/preambel.tex
+++ b/latex/tex/preambel.tex
@@ -40,7 +40,7 @@
 \usepackage[pagebackref=false]{hyperref}  % Hyperlinks
 \usepackage[all]{hypcap}          % Korrekte Verlinkung von Floats
 \usepackage[autostyle=true,german=quotes]{csquotes}   % Zitate
-\usepackage[backend=biber,
+\usepackage[backend=bibtex,
   isbn=false,                     % ISBN nicht anzeigen, gleiches geht mit nahezu allen anderen Feldern
   sortlocale=de_DE,               % Sortierung der Einträge für Deutsch
   %sortlocale=en_US,              % Sortierung der Einträge für Englisch


### PR DESCRIPTION
Edit: It's working with both options after being once compiled with "bibtex" instead of "biber" until there's a new \citation command, then it's working only with "bibtex" instead of "biber". Although I don't know why.

Original comment:
Not sure if this is generally applicable:
Option 1   \usepackage[backend=biber]{biblatex}    didn't work for me*, but
Option 2   \usepackage[backend=bibtex]{biblatex}    works. 

Using Texstudio, BibTex, Citavi.

*Showing no bibliography at all and the citations with the outwritten citation with booktitle, etc. insteald of a nunmber e.g. [1]
Log: "I found no \citation commands---while reading file Test.aux
I found no \bibdata command---while reading file Test.aux
I found no \bibstyle command---while reading file Test.aux
(There were 3 error messages)

Prozess endete mit Fehler(n)"
 

