### PR TITLE
Fix package order bug with footnote hyperrefs

### DIFF
--- a/latex/tex/preambel.tex
+++ b/latex/tex/preambel.tex
@@ -18,6 +18,7 @@
 \usepackage[T1]{fontenc}          % Zeichenkodierung
 \usepackage{graphicx}             % Bilder einbinden
 \usepackage{enumitem}             % Eigene Listen definieren können
+\usepackage{setspace}             % Abstände korrigieren
 
 % Setzen von Optionen abhängig von der gewählten Sprache. Die Sprache wird
 % in thesis.tex gesetzt.
@@ -51,7 +52,6 @@
 \usepackage{calc}                 % Berechnung von Positionen
 \usepackage{blindtext}            % Blindtexte
 \usepackage[bottom=40mm,left=35mm,right=35mm,top=30mm]{geometry} % Ränder ändern
-\usepackage{setspace}             % Abstände korrigieren
 \usepackage{scrhack}              % tocbasic Warnung entfernen
 \usepackage[all]{hypcap}          % Korrekte Verlinkung von Floats
 \usepackage{tabularx}             % Spezielle Tabellen


### PR DESCRIPTION
There's a problem occurring with footnotes and the current order of the packages. 

The footnote-hyperlinks inside the text always link to the title page. More information:
https://tex.stackexchange.com/questions/71664/

Fix is to change the order of the `setspace` package before the `hyperref` package. 