### PR TITLE
Creative Commons-Lizenzen als zusätzliche Veröffentlichungsvereinbarung

### DIFF
--- a/latex/tex/docinfo.tex
+++ b/latex/tex/docinfo.tex
@@ -26,6 +26,12 @@
 \setboolean{hsmapublizieren}{true}   % Einer Veröffentlichung wird zugestimmt
 \setboolean{hsmasperrvermerk}{false} % Die Arbeit hat keinen Sperrvermerk
 
+% "Creative Commons"-Lizenzen (https://creativecommons.org/)
+% wenn Zustimmung zur Veröffentlichung und kein Sperrvermerk 
+%\renewcommand{\hsmacc}{by}
+\renewcommand{\hsmacc}{by-sa}
+%\renewcommand{\hsmacc}{by-nc-sa}
+
 % -------------------------------------------------------
 % Abstract
 % Achtung: Wenn Sie im Abstrakt Anführungszeichen verwenden wollen, dann benutzen Sie

--- a/latex/tex/preambel.tex
+++ b/latex/tex/preambel.tex
@@ -229,6 +229,7 @@
 % Flags für Veröffentlichung und Sperrvermerk
 \newboolean{hsmapublizieren}
 \newboolean{hsmasperrvermerk}
+\newcommand{\hsmacc}{}
 
 % Tabellenzellen mit mehreren Zeilen
 \newcolumntype{L}{>{\raggedright\arraybackslash}X}

--- a/latex/tex/thesis.tex
+++ b/latex/tex/thesis.tex
@@ -96,6 +96,7 @@
 % Dokumenteninfos importieren
 \input{docinfo}
 
+\usepackage[type={CC},modifier={\hsmacc}]{doclicense}
 % Richtige Titel für das Quellcodeverzeichnis
 \renewcommand\lstlistingname{\hsmalistings}
 \renewcommand\lstlistlistingname{\hsmalistings}

--- a/latex/tex/titelblatt.tex
+++ b/latex/tex/titelblatt.tex
@@ -483,8 +483,10 @@ Hiermit erkläre ich, dass ich die vorliegende Arbeit selbstständig verfasst un
 
 \ifthenelse{\boolean{hsmapublizieren} \and \not\boolean{hsmasperrvermerk}}%
 {
-\vspace{0.5cm}
-Ich bin damit einverstanden, dass meine Arbeit veröffentlicht wird, d.\,h. dass die Arbeit elektronisch gespeichert, in andere Formate konvertiert, auf den Servern der Hochschule Mannheim öffentlich zugänglich gemacht und über das Internet verbreitet werden darf.
+	\ifthenelse{\equal{\hsmacc}{}}{
+  \vspace{0.5cm}
+  Ich bin damit einverstanden, dass meine Arbeit veröffentlicht wird, d.\,h. dass die Arbeit elektronisch gespeichert, in andere Formate konvertiert, auf den Servern der Hochschule Mannheim öffentlich zugänglich gemacht und über das Internet verbreitet werden darf.
+  }{\doclicenseThis}
 }{}%
 
 \vspace{1cm}


### PR DESCRIPTION
Über die Umdefinition des Kommandos \hsmacc wir die konkrete Lizenz ausgewählt (CC BY / CC BY-SA / CC BY-SA-NC). Wird \hsmacc nicht geändert, wird die bisherige Veröffentlichungsvereinbarung verwendet. Die Sprache \hsmasprache wird berücksichtigt (zumindest für de und en).