### PR TITLE
Remove Compiler Error thrown by titelblatt.tex

### DIFF
--- a/latex/tex/titelblatt.tex
+++ b/latex/tex/titelblatt.tex
@@ -460,7 +460,7 @@
   \vspace{2mm}
   \hsmabetreuer\\
   \vspace{2mm}
-  \hsmazweitkorrektor
+  \ifthenelse{\isundefined{\hsmazweitkorrektor}}{}{\hsmazweitkorrektor}
 \end{textblock*}
 
 % Bibliographische Informationen


### PR DESCRIPTION
Compiler no longer throws an undefined Sequence Error if \hsmazweitkorrektor ist undefined or commented out