### PR TITLE
Update hma.cls

### DIFF
--- a/latex/tex/hma.cls
+++ b/latex/tex/hma.cls
@@ -107,7 +107,7 @@
 
 % Schriftarten für PDFLaTeX und LuaTex
 \RequirePackage{iftex}
-\ifpdftex{% Unterstützung für PDFTeX
+\ifpdftex% Unterstützung für PDFTeX
 	\RequirePackage{tgtermes}			% Tex Gyre Termes (qtm (Times) als Font für Fließtext)
 	\RequirePackage[utf8]{inputenc}		% Dateien in UTF-8 benutzen
 	\RequirePackage[T1]{fontenc}		% Zeichenkodierung


### PR DESCRIPTION
`\ifpdftex` does not need nor uses the "{" is never closed as well and throws errors Windows at least....