### PR TITLE
Feature: Add linting script with grep and regex

### DIFF
--- a/latex/readme.md
+++ b/latex/readme.md
@@ -57,18 +57,18 @@ Zusätzlich liegt im Verzeichnis `/tex` noch ein Makefile mit dem man die Quelle
 
 Sie können auch eine integrierte Entwicklungsumgebung verwenden. Hierbei haben sich folgende bewährt:
 
-- [TeXnicenter](http://www.texniccenter.org/) für Windows (siehe unten)
-- [Texmaker](http://www.xm1math.net/texmaker/) für Windows, MacOS und Linux
+  * [TeXnicenter](http://www.texniccenter.org/) für Windows (siehe unten)
+  * [Texmaker](http://www.xm1math.net/texmaker/) für Windows, MacOS und Linux
 
 Ausserdem müssen sie LaTeX auf Ihrem Rechner installieren. Bei Linux erfolgt dies einfach über den Paketmanager der verwendeten Distribution, z.B. `sudo apt install texlive-full` für Ubuntu. Für Windows und MacOS empfehlen sich:
 
-- [MikTeX](http://miktex.org/) für Windows
-- [MacTeX](http://tug.org/mactex/) für MacOS
+  * [MikTeX](http://miktex.org/) für Windows
+  * [MacTeX](http://tug.org/mactex/) für MacOS
 
 Für die Verwaltung der Literaturliste wird das BibTeX-Format verwendet (Datei `literatur.bib`). Obwohl Sie diese Datei auch von Hand bearbeiten können, empfiehlt es sich, hierfür ein Werkzeug einzusetzen. Bewährt haben sich:
 
-- [JabRef](http://jabref.sourceforge.net/) für Windows, MacOS und Linux
-- [BibDesk](http://bibdesk.sourceforge.net/) für MacOS
+  * [JabRef](http://jabref.sourceforge.net/) für Windows, MacOS und Linux
+  * [BibDesk](http://bibdesk.sourceforge.net/) für MacOS
 
 Achten Sie darauf, die Dokumente im UTF-8-Format abzulegen. Nur so ist eine plattformunabhängige Verwendung gewährleistet. Die Vorlagen hier sind ebenfalls im UTF-8-Format.
 
@@ -82,37 +82,37 @@ Die Vorlage enthält eine Reihe von Dateien, die Sie teilweise nach Ihren Bedür
 
 Anpassen müssen Sie die folgenden Dateien
 
-- `thesis.tex` - Hauptdokument. Hier müssen Sie weitere Kapitel aus dem Ordner `kapitel` inkludieren.
-- `docinfo.tex` - Bibliografische Informationen zur Arbeit, müssen Sie mit Ihren Daten füllen
-- `hma.cls` - Dokumentenklasse für die Abschlussarbeit
-- `kapitel/abkuerzungen.tex` - Liste der in der Arbeit verwendeten Abkürzungen
-- `kapitel/glossar.tex` - Einträge für ein Glossar
-- `kapitel/symbole.tex` - Einträge für ein Symbol und Einheitenverzeichnis
-- `kapitel/kapitel1.tex` - Beispiel für ein Kapitel
-- `kapitel/kapitel2.tex` - Weiteres Beispiel für ein Kapitel
-- `kapitel/kapitel3.tex` - Weiteres Beispiel für ein Kapitel
-- `kapitel/kapitel4.tex` - Weiteres Beispiel für ein Kapitel
-- `kapitel/anhang-a.tex` - Beispiel für einen Anhang
-- `kapitel/anhang-b.tex` - Beispiel für einen Anhang
-- `literatur.bib` - Literaturdatenbank im BibTeX-Format
-- `bilder/unterschrift.png` - Gescannte Unterschrift für die digitale Abgabe
+  * `thesis.tex` - Hauptdokument. Hier müssen Sie weitere Kapitel aus dem Ordner `kapitel` inkludieren.
+  * `docinfo.tex` - Bibliografische Informationen zur Arbeit, müssen Sie mit Ihren Daten füllen
+  * `hma.cls` - Dokumentenklasse für die Abschlussarbeit
+  * `kapitel/abkuerzungen.tex` - Liste der in der Arbeit verwendeten Abkürzungen
+  * `kapitel/glossar.tex` - Einträge für ein Glossar
+  * `kapitel/symbole.tex` - Einträge für ein Symbol und Einheitenverzeichnis
+  * `kapitel/kapitel1.tex` - Beispiel für ein Kapitel
+  * `kapitel/kapitel2.tex` - Weiteres Beispiel für ein Kapitel
+  * `kapitel/kapitel3.tex` - Weiteres Beispiel für ein Kapitel
+  * `kapitel/kapitel4.tex` - Weiteres Beispiel für ein Kapitel
+  * `kapitel/anhang-a.tex` - Beispiel für einen Anhang
+  * `kapitel/anhang-b.tex` - Beispiel für einen Anhang
+  * `literatur.bib` - Literaturdatenbank im BibTeX-Format
+  * `bilder/unterschrift.png` - Gescannte Unterschrift für die digitale Abgabe
 
 Weitere Kapitel können hinzugefügt werden und dann vom Hauptdokument `thesis.tex` inkludiert.
 
 Normalerweise nicht verändern müssen Sie
 
-- `preambel.tex` - Einstellungen zum Dokument.
-- `studiengaenge.tex` - Bezeichungen der Studiengänge, Fakultäten und Abschlüsse
-- `hma.cls` - Dokumentenklasse für die Abschlussarbeit
+  * `preambel.tex` - Einstellungen zum Dokument.
+  * `studiengaenge.tex` - Bezeichungen der Studiengänge, Fakultäten und Abschlüsse
+  * `hma.cls` - Dokumentenklasse für die Abschlussarbeit
 
 Die Vorlage ist für doppelseitigen Druck optimiert. Wenn Sie die Arbeit einseitig ausdrucken, sieht das Ergebnis seltsam aus, weil es unnötig viele leere Seiten enthält und die Seitenzahlen zwischen rechtem und linkem Rand springen. Für **einseitigen Druck** müssen sie die Datei `preambel.tex` ändern und `twoside=on` in `twoside=off` ändern.
 
 Es gibt drei Ordner
 
-- `/kapitel` - Ablageort für die einzelnen Kapitel
-- `/bilder` - Ablageort für die verwendeten Bilder
-- `/src` - Ablageort für die verwendeten Quelltexte von Programmen, die in der Arbeit gezeigt werden sollen.
-- `/pdfs` - Ablageort für die einzubindende PDF Dokumente
+  * `/kapitel` - Ablageort für die einzelnen Kapitel
+  * `/bilder` - Ablageort für die verwendeten Bilder
+  * `/src` - Ablageort für die verwendeten Quelltexte von Programmen, die in der Arbeit gezeigt werden sollen.
+  * `/pdfs` - Ablageort für die einzubindende PDF Dokumente
 
 Die Datei `thesis-overleaf.zip` dient dem einfachen Import in [Overleaf](https://www.overleaf.com) - siehe nächstes Kapitel.
 
@@ -122,12 +122,12 @@ Wenn Sie dieses Projekt in [Visual Studio Code](https://code.visualstudio.com/) 
 
 ### Einstellungen anpassen
 
-1. Installieren Sie LaTeX-Workshop
-2. Öffnen Sie die Liste der Erweiterungen <img src="images/latex_1.png" style="width: 1em">
-3. Suchen Sie nach "LaTex-Workshop" und klicken Sie auf das Zahnrad<br><img src="images/latex_2.png" style="width: 15em">
-4. Wählen Sie in dem Menue "Extension Settings"
-5. Scrollen Sie runter bis zum Eintrag "LaTeX: Recepies" und klicken Sie auf "Edit settings.json"<br><img src="images/latex_3.png" style="width: 50em">
-6. Fügen Sie hinter `"latex-workshop.latex.recipes": [` ein neues Rezept ein:
+  1. Installieren Sie LaTeX-Workshop
+  2. Öffnen Sie die Liste der Erweiterungen <img src="images/latex_1.png" style="width: 1em">
+  3. Suchen Sie nach "LaTex-Workshop" und klicken Sie auf das Zahnrad<br><img src="images/latex_2.png" style="width: 15em">
+  4. Wählen Sie in dem Menue "Extension Settings"
+  5. Scrollen Sie runter bis zum Eintrag "LaTeX: Recepies" und klicken Sie auf "Edit settings.json"<br><img src="images/latex_3.png" style="width: 50em">
+  6. Fügen Sie hinter `"latex-workshop.latex.recipes": [` ein neues Rezept ein:
 
 ```json
 {
@@ -171,7 +171,7 @@ Vor der letzten schließenden Klammer fügen Sie noch folgendes ein:
             ]
         }
     ]
-```
+  ```
 
 Den vollständigen Abschnitt der Datei finden Sie hier: [settings.json](images/settings.json).
 
@@ -185,51 +185,52 @@ Damit VSCode die thesis.tex als Hauptdatei erkennt, müssen Sie folgende Zeile a
 
 ### Änderungen testen
 
-1. Schließen Sie VSCode und öffnen Sie es neu.
-2. Öffnen Sie das LaTeX-Dokument und klicken Sie auf das Icon von LaTeX-Workshop <img src="images/latex_5.png" style="width: 2em">
-3. Wenn Sie den Punkt "Build LaTeX projekt" aufklappen, sollte ein neuer Menueeintrag vorhanden sein.<br><img src="images/latex_6.png" style="width: 12em">
-4. Durch Klicken auf diesen Punkt können Sie die Arbeit vollständig und korrekt bauen. Da er der erste Punkt ist, sollte er auch standardmäßig bei Änderungen am Projekt ausgeführt werden.
+  1. Schließen Sie VSCode und öffnen Sie es neu.
+  2. Öffnen Sie das LaTeX-Dokument und klicken Sie auf das Icon von LaTeX-Workshop <img src="images/latex_5.png" style="width: 2em">
+  3. Wenn Sie den Punkt "Build LaTeX projekt" aufklappen, sollte ein neuer Menueeintrag vorhanden sein.<br><img src="images/latex_6.png" style="width: 12em">
+  4. Durch Klicken auf diesen Punkt können Sie die Arbeit vollständig und korrekt bauen. Da er der erste Punkt ist, sollte er auch standardmäßig bei Änderungen am Projekt ausgeführt werden.
+
 
 ## LaTeX-Projekt unter Overleaf einrichten
 
-- Laden Sie die ZIP-Version des Projektes [hier](https://github.com/informatik-mannheim/thesis-template/raw/main/latex/thesis-overleaf.zip) herunter.
-- Melden Sie sich bei [Overleaf](https://www.overleaf.com) an und loggen Sie sich ein.
-- Gehen Sie auf "New Project" und wählen Sie "Upload Project"
-- Laden Sie die ZIP-Datei hoch.
-- Sie werden jetzt Compile-Fehler bekommen, aber keine Panik, dies liegt daran, dass Overleaf nicht weiß, welches das Hauptdokument ist
-- Wählen Sie das Overleaf Logo oben links, um das Einstellungsmenue aufzurufen und stellen Sie die Option "Main document" auf `thesis.tex`
-- Wählen Sie nun in der Dateiliste ebenfalls `thesis.tex`
-- Drücken Sie auf "Recompile" - das Projekt sollte jetzt bauen
+ * Laden Sie die ZIP-Version des Projektes [hier](https://github.com/informatik-mannheim/thesis-template/raw/main/latex/thesis-overleaf.zip) herunter.
+ * Melden Sie sich bei [Overleaf](https://www.overleaf.com) an und loggen Sie sich ein.
+ * Gehen Sie auf "New Project" und wählen Sie "Upload Project"
+ * Laden Sie die ZIP-Datei hoch.
+ * Sie werden jetzt Compile-Fehler bekommen, aber keine Panik, dies liegt daran, dass Overleaf nicht weiß, welches das Hauptdokument ist
+ * Wählen Sie das Overleaf Logo oben links, um das Einstellungsmenue aufzurufen und stellen Sie die Option "Main document" auf `thesis.tex`
+ * Wählen Sie nun in der Dateiliste ebenfalls `thesis.tex`
+ * Drücken Sie auf "Recompile" - das Projekt sollte jetzt bauen
 
-Overleaf Premium ermöglicht es mit den Funktionen ["Git-Bridge" und "GitHub Synchronization"](https://de.overleaf.com/learn/how-to/Using_Git_and_GitHub) Änderungen mit einem lokalen Repository oder einem Repository auf GitHub zu synchronisieren. Es ist aus technischen Gründen sinnvoll, das Overleaf-Projekt in einem eigenen Repository zu verwalten, das dann als [_Git Submodul_](https://git-scm.com/book/de/v2/Git-Tools-Submodule) zu einem anderen Repository hinzugefügt werden kann, welches zum Beispiel den Quellcode der Arbeit enthält.
+Overleaf Premium ermöglicht es mit den Funktionen ["Git-Bridge" und "GitHub Synchronization"](https://de.overleaf.com/learn/how-to/Using_Git_and_GitHub) Änderungen mit einem lokalen Repository oder einem Repository auf GitHub zu synchronisieren. Es ist aus technischen Gründen sinnvoll, das Overleaf-Projekt in einem eigenen Repository zu verwalten, das dann als [*Git Submodul*](https://git-scm.com/book/de/v2/Git-Tools-Submodule) zu einem anderen Repository hinzugefügt werden kann, welches zum Beispiel den Quellcode der Arbeit enthält.
 
 ## LaTeX-Projekt unter Texmaker einrichten
 
 [Texmaker](https://www.xm1math.net/texmaker/) unterstützt alle Betriebssysteme.
 
-- Öffnen Sie die Datei `thesis.tex` mit Texmaker
-- Gehen Sie auf "Options" -> "Define current document as 'Master Document'"
-- Gehen Sie auf "Options" -> "Configure Texmaker"
-  - Tragen Sie unter "Commands" -> "Bib(la)tex" als Kommando `biber %` ein<br><img src="images/biber.png" width="400">
-  - Tragen Sie unter "Commands" -> "Makeindex" als Kommando `makeindex -s %.ist -t %.alg -o %.acr %.acn` ein<br><img src="images/makeindex.png" width="400">
-  - Wählen Sie unter "Quick Build" die Option "User"<br><img src="images/user_settings.png" width="400"><br>Und tragen Sie den folgenden String dort ein:<br>`pdflatex -interaction=nonstopmode %.tex|biber %|makeindex -s %.ist -t %.alg -o %.acr %.acn|pdflatex -interaction=nonstopmode %.tex|pdflatex -interaction=nonstopmode %.tex`
-- Wählen Sie in der Menuezeile "Quick Build" aus<br><img src="images/run.png" width="200">
-- Klicken Sie auf den Pfeil links von "Quick Build"
-- Um die aktuelle Version des Dokuments anzuzeigen, klicken Sie auf den Pfeil links von "View PDF".
+  * Öffnen Sie die Datei `thesis.tex` mit Texmaker
+  * Gehen Sie auf "Options" -> "Define current document as 'Master Document'"
+  * Gehen Sie auf "Options" -> "Configure Texmaker"
+    * Tragen Sie unter "Commands" -> "Bib(la)tex" als Kommando `biber %` ein<br><img src="images/biber.png" width="400">
+    * Tragen Sie unter "Commands" -> "Makeindex" als Kommando `makeindex -s %.ist -t %.alg -o %.acr %.acn` ein<br><img src="images/makeindex.png" width="400">
+    * Wählen Sie unter "Quick Build" die Option "User"<br><img src="images/user_settings.png" width="400"><br>Und tragen Sie den folgenden String dort ein:<br>`pdflatex -interaction=nonstopmode %.tex|biber %|makeindex -s %.ist -t %.alg -o %.acr %.acn|pdflatex -interaction=nonstopmode %.tex|pdflatex -interaction=nonstopmode %.tex`
+  * Wählen Sie in der Menuezeile "Quick Build" aus<br><img src="images/run.png" width="200">
+  * Klicken Sie auf den Pfeil links von "Quick Build"
+  * Um die aktuelle Version des Dokuments anzuzeigen, klicken Sie auf den Pfeil links von "View PDF".
 
 ## LaTeX-Projekt unter TeXnicCenter einrichten
 
 Ab der Version 2 von TeXnicCenter wird das UTF-8-Format richtig unterstützt.
 
-- Öffnen Sie die Datei `thesis.tex` mit TeXnicCenter
-- Wählen Sie in Projekt "Erzeugen mit aktueller Datei als Hauptdatei"
-  - "verwendet BibTex" ankreuzen
-  - "verwendet Makeindex" ankreuzen
-  - Sprachinformation für die Rechtschreibkorrektur setzen
-- Unter "Ausgabe" den Punkt "Ausgabeprofil definieren" wählen
-  - LaTeX => PDF auswählen
-  - "Pfade des BibTeX-Compilers" von `...\bibtex.exe` auf `...\biber.exe` ändern
-- Unter "Ausgabe" den Punkt "Aktive Ausgabeprofil wählen" anklicken
-  - LaTeX => PDF auswählen
+  * Öffnen Sie die Datei `thesis.tex` mit TeXnicCenter
+  * Wählen Sie in Projekt "Erzeugen mit aktueller Datei als Hauptdatei"
+    * "verwendet BibTex" ankreuzen
+    * "verwendet Makeindex" ankreuzen
+    * Sprachinformation für die Rechtschreibkorrektur setzen
+  * Unter "Ausgabe" den Punkt "Ausgabeprofil definieren" wählen
+    * LaTeX => PDF auswählen
+    * "Pfade des BibTeX-Compilers" von `...\bibtex.exe` auf `...\biber.exe` ändern
+  * Unter "Ausgabe" den Punkt "Aktive Ausgabeprofil wählen" anklicken
+    * LaTeX => PDF auswählen
 
 Damit alle Referenzen und Literaturangaben im Dokument korrekt sind, müssen Sie es bis zu drei Mal erzeugen.

--- a/latex/readme.md
+++ b/latex/readme.md
@@ -14,6 +14,41 @@ Wenn Ihnen die Vorlage gefällt, können Sie diesem _Repo einen Stern geben_ - d
 
 ## Werkzeuge, Dateiformat
 
+### Überprüfung mit Regex
+
+Wenn Sie über Regex Ihren Text auf ein paar Regeln überprüfen möchten, können
+Sie dafür das bereitgestellte [`lint.sh`](./tex/scripts/lint.sh) Skript verwenden. Sie können ebenfalls
+`make lint` verwenden, um das Skript ausführen zu lassen. Wichtig: damit das
+Skript funktioniert muss `jq` installiert sein!
+
+Um das Skript sinnvoll verwenden zu können, müssen Sie möglicherweise die Regeln
+anpassen. Dafür müssen Sie die [`rules.json`](./tex/rules.json) Datei bearbeiten. Eine Regel ist
+dabei wiefolgt aufgebaut:
+
+```json
+{
+  "title": "Der Titel",
+  "rule": "Die Regel als Regex. Das landet später in 'grep', daher sollten Sie
+  den Regex-Syntax von 'grep' verwenden!",
+  "args": ["zusätzliche", "Argumente", "für", "grep"],
+  "excludes": ["thesis.tex", "Dateien die ignoriert werden sollen"],
+  "includes": ["rules.json", "Dateien die in jedem Fall überprüft werden sollen"],
+  "mustContain": false
+}
+```
+
+Standardmäßig wird für das `grep` immer `--color=always` sowie `-Eq` bzw. `-En`
+mitgegeben, je nachdem ob `mustContain` auf `true` oder `false` ist. Das Skript
+überprüft auch keine Kommentare, sondern nur Ihre Makros und tatsächlichen Text.
+
+Standardmäßig werden _alle_ Dateien im [`/tex`](./tex) Verzeichnis mit der
+Endung `.tex` überprüft. Das kann durch `excludes` und `includes` entsprechend
+angepasst werden.
+
+Falls Sie eigene Regeln erstellen wollen, schauen Sie sich am Besten die
+Standardregeln in der [`rules.json`](./tex/rules.json) an, da sollten Sie alle
+relevanten Beispiele finden.
+
 ### Lokale Entwicklungsumgebungen
 
 Zum Erzeugen der fertigen Arbeit dienen die Skripte `create` und `clean`. Die .cmd-Version ist für Windows, die .sh für Unix/Linux.
@@ -22,18 +57,18 @@ Zusätzlich liegt im Verzeichnis `/tex` noch ein Makefile mit dem man die Quelle
 
 Sie können auch eine integrierte Entwicklungsumgebung verwenden. Hierbei haben sich folgende bewährt:
 
-  * [TeXnicenter](http://www.texniccenter.org/) für Windows (siehe unten)
-  * [Texmaker](http://www.xm1math.net/texmaker/) für Windows, MacOS und Linux
+- [TeXnicenter](http://www.texniccenter.org/) für Windows (siehe unten)
+- [Texmaker](http://www.xm1math.net/texmaker/) für Windows, MacOS und Linux
 
 Ausserdem müssen sie LaTeX auf Ihrem Rechner installieren. Bei Linux erfolgt dies einfach über den Paketmanager der verwendeten Distribution, z.B. `sudo apt install texlive-full` für Ubuntu. Für Windows und MacOS empfehlen sich:
 
-  * [MikTeX](http://miktex.org/) für Windows
-  * [MacTeX](http://tug.org/mactex/) für MacOS
+- [MikTeX](http://miktex.org/) für Windows
+- [MacTeX](http://tug.org/mactex/) für MacOS
 
 Für die Verwaltung der Literaturliste wird das BibTeX-Format verwendet (Datei `literatur.bib`). Obwohl Sie diese Datei auch von Hand bearbeiten können, empfiehlt es sich, hierfür ein Werkzeug einzusetzen. Bewährt haben sich:
 
-  * [JabRef](http://jabref.sourceforge.net/) für Windows, MacOS und Linux
-  * [BibDesk](http://bibdesk.sourceforge.net/) für MacOS
+- [JabRef](http://jabref.sourceforge.net/) für Windows, MacOS und Linux
+- [BibDesk](http://bibdesk.sourceforge.net/) für MacOS
 
 Achten Sie darauf, die Dokumente im UTF-8-Format abzulegen. Nur so ist eine plattformunabhängige Verwendung gewährleistet. Die Vorlagen hier sind ebenfalls im UTF-8-Format.
 
@@ -47,37 +82,37 @@ Die Vorlage enthält eine Reihe von Dateien, die Sie teilweise nach Ihren Bedür
 
 Anpassen müssen Sie die folgenden Dateien
 
-  * `thesis.tex` - Hauptdokument. Hier müssen Sie weitere Kapitel aus dem Ordner `kapitel` inkludieren.
-  * `docinfo.tex` - Bibliografische Informationen zur Arbeit, müssen Sie mit Ihren Daten füllen
-  * `hma.cls` - Dokumentenklasse für die Abschlussarbeit
-  * `kapitel/abkuerzungen.tex` - Liste der in der Arbeit verwendeten Abkürzungen
-  * `kapitel/glossar.tex` - Einträge für ein Glossar
-  * `kapitel/symbole.tex` - Einträge für ein Symbol und Einheitenverzeichnis
-  * `kapitel/kapitel1.tex` - Beispiel für ein Kapitel
-  * `kapitel/kapitel2.tex` - Weiteres Beispiel für ein Kapitel
-  * `kapitel/kapitel3.tex` - Weiteres Beispiel für ein Kapitel
-  * `kapitel/kapitel4.tex` - Weiteres Beispiel für ein Kapitel
-  * `kapitel/anhang-a.tex` - Beispiel für einen Anhang
-  * `kapitel/anhang-b.tex` - Beispiel für einen Anhang
-  * `literatur.bib` - Literaturdatenbank im BibTeX-Format
-  * `bilder/unterschrift.png` - Gescannte Unterschrift für die digitale Abgabe
+- `thesis.tex` - Hauptdokument. Hier müssen Sie weitere Kapitel aus dem Ordner `kapitel` inkludieren.
+- `docinfo.tex` - Bibliografische Informationen zur Arbeit, müssen Sie mit Ihren Daten füllen
+- `hma.cls` - Dokumentenklasse für die Abschlussarbeit
+- `kapitel/abkuerzungen.tex` - Liste der in der Arbeit verwendeten Abkürzungen
+- `kapitel/glossar.tex` - Einträge für ein Glossar
+- `kapitel/symbole.tex` - Einträge für ein Symbol und Einheitenverzeichnis
+- `kapitel/kapitel1.tex` - Beispiel für ein Kapitel
+- `kapitel/kapitel2.tex` - Weiteres Beispiel für ein Kapitel
+- `kapitel/kapitel3.tex` - Weiteres Beispiel für ein Kapitel
+- `kapitel/kapitel4.tex` - Weiteres Beispiel für ein Kapitel
+- `kapitel/anhang-a.tex` - Beispiel für einen Anhang
+- `kapitel/anhang-b.tex` - Beispiel für einen Anhang
+- `literatur.bib` - Literaturdatenbank im BibTeX-Format
+- `bilder/unterschrift.png` - Gescannte Unterschrift für die digitale Abgabe
 
 Weitere Kapitel können hinzugefügt werden und dann vom Hauptdokument `thesis.tex` inkludiert.
 
 Normalerweise nicht verändern müssen Sie
 
-  * `preambel.tex` - Einstellungen zum Dokument.
-  * `studiengaenge.tex` - Bezeichungen der Studiengänge, Fakultäten und Abschlüsse
-  * `hma.cls` - Dokumentenklasse für die Abschlussarbeit
+- `preambel.tex` - Einstellungen zum Dokument.
+- `studiengaenge.tex` - Bezeichungen der Studiengänge, Fakultäten und Abschlüsse
+- `hma.cls` - Dokumentenklasse für die Abschlussarbeit
 
 Die Vorlage ist für doppelseitigen Druck optimiert. Wenn Sie die Arbeit einseitig ausdrucken, sieht das Ergebnis seltsam aus, weil es unnötig viele leere Seiten enthält und die Seitenzahlen zwischen rechtem und linkem Rand springen. Für **einseitigen Druck** müssen sie die Datei `preambel.tex` ändern und `twoside=on` in `twoside=off` ändern.
 
 Es gibt drei Ordner
 
-  * `/kapitel` - Ablageort für die einzelnen Kapitel
-  * `/bilder` - Ablageort für die verwendeten Bilder
-  * `/src` - Ablageort für die verwendeten Quelltexte von Programmen, die in der Arbeit gezeigt werden sollen.
-  * `/pdfs` - Ablageort für die einzubindende PDF Dokumente
+- `/kapitel` - Ablageort für die einzelnen Kapitel
+- `/bilder` - Ablageort für die verwendeten Bilder
+- `/src` - Ablageort für die verwendeten Quelltexte von Programmen, die in der Arbeit gezeigt werden sollen.
+- `/pdfs` - Ablageort für die einzubindende PDF Dokumente
 
 Die Datei `thesis-overleaf.zip` dient dem einfachen Import in [Overleaf](https://www.overleaf.com) - siehe nächstes Kapitel.
 
@@ -87,12 +122,12 @@ Wenn Sie dieses Projekt in [Visual Studio Code](https://code.visualstudio.com/) 
 
 ### Einstellungen anpassen
 
-  1. Installieren Sie LaTeX-Workshop
-  2. Öffnen Sie die Liste der Erweiterungen <img src="images/latex_1.png" style="width: 1em">
-  3. Suchen Sie nach "LaTex-Workshop" und klicken Sie auf das Zahnrad<br><img src="images/latex_2.png" style="width: 15em">
-  4. Wählen Sie in dem Menue "Extension Settings"
-  5. Scrollen Sie runter bis zum Eintrag "LaTeX: Recepies" und klicken Sie auf "Edit settings.json"<br><img src="images/latex_3.png" style="width: 50em">
-  6. Fügen Sie hinter `"latex-workshop.latex.recipes": [` ein neues Rezept ein:
+1. Installieren Sie LaTeX-Workshop
+2. Öffnen Sie die Liste der Erweiterungen <img src="images/latex_1.png" style="width: 1em">
+3. Suchen Sie nach "LaTex-Workshop" und klicken Sie auf das Zahnrad<br><img src="images/latex_2.png" style="width: 15em">
+4. Wählen Sie in dem Menue "Extension Settings"
+5. Scrollen Sie runter bis zum Eintrag "LaTeX: Recepies" und klicken Sie auf "Edit settings.json"<br><img src="images/latex_3.png" style="width: 50em">
+6. Fügen Sie hinter `"latex-workshop.latex.recipes": [` ein neues Rezept ein:
 
 ```json
 {
@@ -136,7 +171,7 @@ Vor der letzten schließenden Klammer fügen Sie noch folgendes ein:
             ]
         }
     ]
-  ```
+```
 
 Den vollständigen Abschnitt der Datei finden Sie hier: [settings.json](images/settings.json).
 
@@ -150,52 +185,51 @@ Damit VSCode die thesis.tex als Hauptdatei erkennt, müssen Sie folgende Zeile a
 
 ### Änderungen testen
 
-  1. Schließen Sie VSCode und öffnen Sie es neu.
-  2. Öffnen Sie das LaTeX-Dokument und klicken Sie auf das Icon von LaTeX-Workshop <img src="images/latex_5.png" style="width: 2em">
-  3. Wenn Sie den Punkt "Build LaTeX projekt" aufklappen, sollte ein neuer Menueeintrag vorhanden sein.<br><img src="images/latex_6.png" style="width: 12em">
-  4. Durch Klicken auf diesen Punkt können Sie die Arbeit vollständig und korrekt bauen. Da er der erste Punkt ist, sollte er auch standardmäßig bei Änderungen am Projekt ausgeführt werden.
-
+1. Schließen Sie VSCode und öffnen Sie es neu.
+2. Öffnen Sie das LaTeX-Dokument und klicken Sie auf das Icon von LaTeX-Workshop <img src="images/latex_5.png" style="width: 2em">
+3. Wenn Sie den Punkt "Build LaTeX projekt" aufklappen, sollte ein neuer Menueeintrag vorhanden sein.<br><img src="images/latex_6.png" style="width: 12em">
+4. Durch Klicken auf diesen Punkt können Sie die Arbeit vollständig und korrekt bauen. Da er der erste Punkt ist, sollte er auch standardmäßig bei Änderungen am Projekt ausgeführt werden.
 
 ## LaTeX-Projekt unter Overleaf einrichten
 
- * Laden Sie die ZIP-Version des Projektes [hier](https://github.com/informatik-mannheim/thesis-template/raw/main/latex/thesis-overleaf.zip) herunter.
- * Melden Sie sich bei [Overleaf](https://www.overleaf.com) an und loggen Sie sich ein.
- * Gehen Sie auf "New Project" und wählen Sie "Upload Project"
- * Laden Sie die ZIP-Datei hoch.
- * Sie werden jetzt Compile-Fehler bekommen, aber keine Panik, dies liegt daran, dass Overleaf nicht weiß, welches das Hauptdokument ist
- * Wählen Sie das Overleaf Logo oben links, um das Einstellungsmenue aufzurufen und stellen Sie die Option "Main document" auf `thesis.tex`
- * Wählen Sie nun in der Dateiliste ebenfalls `thesis.tex`
- * Drücken Sie auf "Recompile" - das Projekt sollte jetzt bauen
+- Laden Sie die ZIP-Version des Projektes [hier](https://github.com/informatik-mannheim/thesis-template/raw/main/latex/thesis-overleaf.zip) herunter.
+- Melden Sie sich bei [Overleaf](https://www.overleaf.com) an und loggen Sie sich ein.
+- Gehen Sie auf "New Project" und wählen Sie "Upload Project"
+- Laden Sie die ZIP-Datei hoch.
+- Sie werden jetzt Compile-Fehler bekommen, aber keine Panik, dies liegt daran, dass Overleaf nicht weiß, welches das Hauptdokument ist
+- Wählen Sie das Overleaf Logo oben links, um das Einstellungsmenue aufzurufen und stellen Sie die Option "Main document" auf `thesis.tex`
+- Wählen Sie nun in der Dateiliste ebenfalls `thesis.tex`
+- Drücken Sie auf "Recompile" - das Projekt sollte jetzt bauen
 
-Overleaf Premium ermöglicht es mit den Funktionen ["Git-Bridge" und "GitHub Synchronization"](https://de.overleaf.com/learn/how-to/Using_Git_and_GitHub) Änderungen mit einem lokalen Repository oder einem Repository auf GitHub zu synchronisieren. Es ist aus technischen Gründen sinnvoll, das Overleaf-Projekt in einem eigenen Repository zu verwalten, das dann als [*Git Submodul*](https://git-scm.com/book/de/v2/Git-Tools-Submodule) zu einem anderen Repository hinzugefügt werden kann, welches zum Beispiel den Quellcode der Arbeit enthält.
+Overleaf Premium ermöglicht es mit den Funktionen ["Git-Bridge" und "GitHub Synchronization"](https://de.overleaf.com/learn/how-to/Using_Git_and_GitHub) Änderungen mit einem lokalen Repository oder einem Repository auf GitHub zu synchronisieren. Es ist aus technischen Gründen sinnvoll, das Overleaf-Projekt in einem eigenen Repository zu verwalten, das dann als [_Git Submodul_](https://git-scm.com/book/de/v2/Git-Tools-Submodule) zu einem anderen Repository hinzugefügt werden kann, welches zum Beispiel den Quellcode der Arbeit enthält.
 
 ## LaTeX-Projekt unter Texmaker einrichten
 
 [Texmaker](https://www.xm1math.net/texmaker/) unterstützt alle Betriebssysteme.
 
-  * Öffnen Sie die Datei `thesis.tex` mit Texmaker
-  * Gehen Sie auf "Options" -> "Define current document as 'Master Document'"
-  * Gehen Sie auf "Options" -> "Configure Texmaker"
-    * Tragen Sie unter "Commands" -> "Bib(la)tex" als Kommando `biber %` ein<br><img src="images/biber.png" width="400">
-    * Tragen Sie unter "Commands" -> "Makeindex" als Kommando `makeindex -s %.ist -t %.alg -o %.acr %.acn` ein<br><img src="images/makeindex.png" width="400">
-    * Wählen Sie unter "Quick Build" die Option "User"<br><img src="images/user_settings.png" width="400"><br>Und tragen Sie den folgenden String dort ein:<br>`pdflatex -interaction=nonstopmode %.tex|biber %|makeindex -s %.ist -t %.alg -o %.acr %.acn|pdflatex -interaction=nonstopmode %.tex|pdflatex -interaction=nonstopmode %.tex`
-  * Wählen Sie in der Menuezeile "Quick Build" aus<br><img src="images/run.png" width="200">
-  * Klicken Sie auf den Pfeil links von "Quick Build"
-  * Um die aktuelle Version des Dokuments anzuzeigen, klicken Sie auf den Pfeil links von "View PDF".
+- Öffnen Sie die Datei `thesis.tex` mit Texmaker
+- Gehen Sie auf "Options" -> "Define current document as 'Master Document'"
+- Gehen Sie auf "Options" -> "Configure Texmaker"
+  - Tragen Sie unter "Commands" -> "Bib(la)tex" als Kommando `biber %` ein<br><img src="images/biber.png" width="400">
+  - Tragen Sie unter "Commands" -> "Makeindex" als Kommando `makeindex -s %.ist -t %.alg -o %.acr %.acn` ein<br><img src="images/makeindex.png" width="400">
+  - Wählen Sie unter "Quick Build" die Option "User"<br><img src="images/user_settings.png" width="400"><br>Und tragen Sie den folgenden String dort ein:<br>`pdflatex -interaction=nonstopmode %.tex|biber %|makeindex -s %.ist -t %.alg -o %.acr %.acn|pdflatex -interaction=nonstopmode %.tex|pdflatex -interaction=nonstopmode %.tex`
+- Wählen Sie in der Menuezeile "Quick Build" aus<br><img src="images/run.png" width="200">
+- Klicken Sie auf den Pfeil links von "Quick Build"
+- Um die aktuelle Version des Dokuments anzuzeigen, klicken Sie auf den Pfeil links von "View PDF".
 
 ## LaTeX-Projekt unter TeXnicCenter einrichten
 
 Ab der Version 2 von TeXnicCenter wird das UTF-8-Format richtig unterstützt.
 
-  * Öffnen Sie die Datei `thesis.tex` mit TeXnicCenter
-  * Wählen Sie in Projekt "Erzeugen mit aktueller Datei als Hauptdatei"
-    * "verwendet BibTex" ankreuzen
-    * "verwendet Makeindex" ankreuzen
-    * Sprachinformation für die Rechtschreibkorrektur setzen
-  * Unter "Ausgabe" den Punkt "Ausgabeprofil definieren" wählen
-    * LaTeX => PDF auswählen
-    * "Pfade des BibTeX-Compilers" von `...\bibtex.exe` auf `...\biber.exe` ändern
-  * Unter "Ausgabe" den Punkt "Aktive Ausgabeprofil wählen" anklicken
-    * LaTeX => PDF auswählen
+- Öffnen Sie die Datei `thesis.tex` mit TeXnicCenter
+- Wählen Sie in Projekt "Erzeugen mit aktueller Datei als Hauptdatei"
+  - "verwendet BibTex" ankreuzen
+  - "verwendet Makeindex" ankreuzen
+  - Sprachinformation für die Rechtschreibkorrektur setzen
+- Unter "Ausgabe" den Punkt "Ausgabeprofil definieren" wählen
+  - LaTeX => PDF auswählen
+  - "Pfade des BibTeX-Compilers" von `...\bibtex.exe` auf `...\biber.exe` ändern
+- Unter "Ausgabe" den Punkt "Aktive Ausgabeprofil wählen" anklicken
+  - LaTeX => PDF auswählen
 
 Damit alle Referenzen und Literaturangaben im Dokument korrekt sind, müssen Sie es bis zu drei Mal erzeugen.

--- a/latex/readme.md
+++ b/latex/readme.md
@@ -28,8 +28,7 @@ dabei wiefolgt aufgebaut:
 ```json
 {
   "title": "Der Titel",
-  "rule": "Die Regel als Regex. Das landet später in 'grep', daher sollten Sie
-  den Regex-Syntax von 'grep' verwenden!",
+  "rule": "Die Regel als Regex. Das landet später in 'grep', daher sollten Sie den Regex-Syntax von 'grep' verwenden!",
   "args": ["zusätzliche", "Argumente", "für", "grep"],
   "excludes": ["thesis.tex", "Dateien die ignoriert werden sollen"],
   "includes": ["rules.json", "Dateien die in jedem Fall überprüft werden sollen"],

--- a/latex/tex/Makefile
+++ b/latex/tex/Makefile
@@ -33,6 +33,10 @@ clean:
 	rm -rf $(RESULT_DIR)
 	rm -f $(TEMP_FILES)
 
+.PHONY: lint
+lint:
+		./scripts/lint.sh
+
 ../thesis-overleaf.zip: $(INCLUDES) $(CHAPTERS) thesis.tex
 	rm -f $(TEMP_FILES)
 	rm $@

--- a/latex/tex/docinfo.tex
+++ b/latex/tex/docinfo.tex
@@ -2,6 +2,8 @@
 % Informationen und Einstellungen für Ihre Abschlussarbeit
 %
 
+\newcommand{\seesettingsmarker}
+
 % Sprache für das Dokument festlegen
 \newcommand{\hsmasprache}{de} %de für Deutsch oder en für Englisch
 

--- a/latex/tex/docinfo.tex
+++ b/latex/tex/docinfo.tex
@@ -47,13 +47,13 @@
 
 % Weitere Informationen zur Arbeit
 \newcommand{\hsmaort}{Mannheim}          % Ort
-\newcommand{\hsmaautorvname}{Max}        % Vorname(n)
-\newcommand{\hsmaautornname}{Mustermann} % Nachname(n)
+\newcommand{\hsmaautorvname}{Maxxx}        % Vorname(n)
+\newcommand{\hsmaautornname}{Mustermannn} % Nachname(n)
 \newcommand{\hsmaabgabedatum}{2025-08-08}% Datum der Abgabe in dem Format JJJJ-MM-TT
 
 \newcommand{\hsmafirma}{Paukenschlag GmbH, Mannheim} % Firma bei der die Arbeit durchgeführt wurde
-\newcommand{\hsmabetreuer}{Prof. Peter Mustermann, Technische Hochschule Mannheim} % Betreuer an der Hochschule
-\newcommand{\hsmazweitkorrektor}{Erika Mustermann, Paukenschlag GmbH}   % Betreuer im Unternehmen oder Zweitkorrektor
+\newcommand{\hsmabetreuer}{Prof. Peter Mustermannn, Technische Hochschule Mannheim} % Betreuer an der Hochschule
+\newcommand{\hsmazweitkorrektor}{Erika Mustermannn, Paukenschlag GmbH}   % Betreuer im Unternehmen oder Zweitkorrektor
 
 \newcommand{\hsmafakultaet}{I}    % I für Informatik oder E, S, B, D, M, N, W, V
 \newcommand{\hsmastudiengang}{IB} % IB IMB UIB CSB IM MTB (weitere siehe titleblatt.tex)

--- a/latex/tex/kapitel/kapitel3.tex
+++ b/latex/tex/kapitel/kapitel3.tex
@@ -216,7 +216,7 @@ In diesem Dokument können Track Changes \chreplaced[id=B1]{verwendet}{aktiviert
 Es ist ebenfalls möglich Textteile \chhighlight[id=B1]{hervorzuheben} mit dem Befehl \\ \lstinline|\chhighlight[id=B1]{hervorzuheben}|. Zudem können Kommentare\chcomment[id=B2]{das ist mein Kommentar} über den Befehl \lstinline|\chcomment[id=B2]{das ist mein Kommentar}| hinzugefügt werden.
 
 
-Das Verzeichnis zur Ausgabe aller Änderungen erfolgt über das Flag \lstinline|tc| in der docinfo.tex.  Dieser Befehl ist vor der Abgabe unbedingt auf \lstinline|notc| zu ändern.
+Das Verzeichnis zur Ausgabe aller Änderungen erfolgt über das Flag \lstinline|tc| in der docinfo.tex. Dieser Befehl ist vor der Abgabe unbedingt auf \lstinline|notc| zu ändern.
 
 Weitere Informationen zu der Nutzung des Paketes finden Sie unter: \url{https://ctan.org/pkg/changes?lang=de}
 

--- a/latex/tex/rules.json
+++ b/latex/tex/rules.json
@@ -4,6 +4,42 @@
     "rule": "\\\\newcommand\\{\\\\.*marker.*\\}"
   },
   {
+    "title": "Titel geändert",
+    "rule": "(Einsatz eines Flux-Kompensators für Zeitreisen mit einer maximalen Höchstgeschwindigkeit von WARP~7)|(Application of a flux compensator for timetravel with a maximum velocity of warp~7)",
+    "excludes": ["*"],
+    "includes": ["docinfo.tex"]
+  },
+  {
+    "title": "Name geändert",
+    "rule": "(hsmaautorvname..Maxxx)|(hsmaautornname..Mustermannn)",
+    "excludes": ["*"],
+    "includes": ["docinfo.tex"]
+  },
+  {
+    "title": "Abgabedatum geändert",
+    "rule": "hsmaabgabedatum..2025-08-08",
+    "excludes": ["*"],
+    "includes": ["docinfo.tex"]
+  },
+  {
+    "title": "Firma geändert",
+    "rule": "hsmafirma..Paukenschlag GmbH, Mannheim",
+    "excludes": ["*"],
+    "includes": ["docinfo.tex"]
+  },
+  {
+    "title": "Betreuer geändert",
+    "rule": "hsmabetreuer..Prof. Peter Mustermannn, Technische Hochschule Mannheim",
+    "excludes": ["*"],
+    "includes": ["docinfo.tex"]
+  },
+  {
+    "title": "Zweitkorrektor geändert",
+    "rule": "hsmazweitkorrektor..Erika Mustermannn, Paukenschlag GmbH",
+    "excludes": ["*"],
+    "includes": ["docinfo.tex"]
+  },
+  {
     "title": "Verbiete das Wort 'Abschlussarbeit'",
     "rule": "Abschlussarbeit"
   },

--- a/latex/tex/rules.json
+++ b/latex/tex/rules.json
@@ -1,0 +1,33 @@
+[
+  {
+    "title": "Keine ungelesenen Markierungen",
+    "rule": "\\\\newcommand\\{\\\\.*marker.*\\}"
+  },
+  {
+    "title": "Verbiete das Wort 'Abschlussarbeit'",
+    "rule": "Abschlussarbeit"
+  },
+  {
+    "title": "Verbiete mehr wie ein Leerzeichen im Text",
+    "rule": "[[:alnum:]_\\.,][\t ]{2,}[[:alnum:]_\\.,]+"
+  },
+  {
+    "title": "Kein Punkt vor dem Zitieren",
+    "rule": "\\. *\\\\autocite\\{.*\\}"
+  },
+  {
+    "title": "Kein Komma vor 'sowie'",
+    "rule": ", *sowie"
+  },
+  {
+    "title": "Immer Komma vor 'sondern'",
+    "rule": "[^,] sondern"
+  },
+  {
+    "title": "Ein Kapitel hat immer ein Chapter",
+    "rule": "\\\\chapter\\{.+\\}",
+    "excludes": ["*"],
+    "includes": ["kapitel*.tex"],
+    "mustContain": true
+  }
+]

--- a/latex/tex/scripts/lint.sh
+++ b/latex/tex/scripts/lint.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+FILES="$*"                                   # the files to check
+BASE_DIR="$(dirname "${BASH_SOURCE[0]}")/.." # the /tex directory
+RULES_FILE="$BASE_DIR/rules.json"            # the location of the "rules.json" file, going from the /tex directory
+EXIT_CODE=0
+
+if [ -z "$FILES" ]; then
+  # by default, check all .tex files
+  # excluding /build
+  # excluding /.git
+
+  FILES=$(
+    find . \
+      -type f \
+      -name "*.tex" \
+      ! -path "./build/*" \
+      ! -path "./.git/*"
+  )
+fi
+
+# Helper function to convert an JSON array into an bash one.
+json_to_arr() {
+  local content="$1"
+  if [ "$content" != "null" ]; then
+    content=$(echo "$content" | jq -r ".[]")
+    readarray -t content <<<"$content"
+  else
+    content=()
+  fi
+  echo "${content[@]}"
+}
+
+# This function adjusts the base files from the "find" on the very top.
+# it excludes anything matching partially defined in the "excludes" part of the
+# JSON rule and afterwards adds anything new it find from the "includes" part
+# of the JSON. Meaning "includes" always takes highest priority
+filter_and_add_files() {
+  local files=$1
+  local excludes=$2
+  local includes=$3
+  local new_files=""
+
+  local filtered=()
+  local filter_all=false
+  for exclude in "${excludes[@]}"; do
+    if [[ "$excludes" == "*" ]]; then
+      filter_all=true
+    fi
+  done
+  if [[ "$filter_all" == false ]]; then
+    for file in "${files[@]}"; do
+      local excluded=false
+      for exclude in "${excludes[@]}"; do
+        if [[ "$exclude" == "" ]]; then
+          continue
+        fi
+        if [[ "$file" == *"$exclude"* ]]; then
+          excluded=true
+          break
+        fi
+      done
+      if [[ "$excluded" != true ]]; then
+        filtered+=("$file")
+      fi
+    done
+  fi
+
+  for include in "${includes[@]}"; do
+    if [[ "$include" == "" ]]; then
+      continue
+    fi
+    new_files=$(find . -type f -name "*$include*")
+    for file in "${new_files[@]}"; do
+      filtered+=("$file")
+    done
+  done
+
+  echo "${filtered[@]}"
+}
+
+print_result() {
+  local result=$1
+  local title=$2
+  local file=$3
+  local not=$4
+  local is_first=$5
+
+  if [[ "$is_first" == true ]]; then
+    echo ""
+  fi
+  echo ""
+  echo "$result"
+  echo ""
+  printf "❌ Verletzung: '%s' " "$title"
+  if [[ "$not" == true ]]; then
+    printf "nicht "
+  fi
+  printf "gefunden in '%s'" "$file"
+  echo ""
+}
+
+RULES_NEWLINE=$(jq -c ".[]" "$RULES_FILE")
+readarray -t RULES_ARRAY <<<"$RULES_NEWLINE"
+
+for rule in "${RULES_ARRAY[@]}"; do
+  TITLE=$(echo "$rule" | jq -r ".title")
+  REGEX=$(echo "$rule" | jq -r ".rule")
+  ARGS=$(echo "$rule" | jq -r ".args")
+  EXCLUDES=$(echo "$rule" | jq -r ".excludes")
+  INCLUDES=$(echo "$rule" | jq -r ".includes")
+  MUST_CONTAIN=$(echo "$rule" | jq -r ".mustContain")
+
+  ARGS=$(json_to_arr "$ARGS")
+  EXCLUDES=$(json_to_arr "$EXCLUDES")
+  INCLUDES=$(json_to_arr "$INCLUDES")
+
+  if [[ "${#ARGS[@]}" -eq 1 ]] && [[ "${ARGS[1]}" == "" ]]; then
+    ARGS=()
+  fi
+  ARGS+=("--color=always")
+
+  IFS=$'\n' # Internal Field Seperator
+  FILES_TO_CHECK=()
+  mapfile -t FILES_TO_CHECK < <(filter_and_add_files "$FILES" "${EXCLUDES[@]}" "${INCLUDES[@]}")
+
+  printf "🔎 %s " "$TITLE"
+
+  if [ "${FILES_TO_CHECK[*]}" == "" ]; then
+    echo "⚠️ Warnung: Keine Dateien für diese Regel gefunden!"
+  else
+    no_violation=true
+    is_first=true
+    for file in "${FILES_TO_CHECK[@]}"; do
+      # probably not the most efficient way of doing things, but it should be
+      # fine since the script will likely only be used every now and then
+      # anyways (and this way comments are ignored from the rules)
+      contents=$(cat "$file" | sed 's/ *%.*//') # remove comments from checks
+      if [ "$MUST_CONTAIN" == "true" ]; then
+        # grep for "must exist"
+        if ! result=$(echo "$contents" | grep "${ARGS[@]}" -Eq "$REGEX"); then
+          print_result "$result" "$TITLE" "$file" true "$is_first"
+          no_violation=false
+          is_first=false
+          EXIT_CODE=1
+        fi
+      else
+        # grep for "must not exist"
+        if result=$(echo "$contents" | grep "${ARGS[@]}" -En "$REGEX"); then
+          print_result "$result" "$TITLE" "$file" false "$is_first"
+          no_violation=false
+          is_first=false
+          EXIT_CODE=1
+        fi
+      fi
+    done
+    if [[ "$no_violation" == true ]]; then
+      printf "✅\n"
+    else
+      echo "----------------------------------------------------------------"
+    fi
+  fi
+
+done
+
+exit "$EXIT_CODE"

--- a/latex/tex/thesis.tex
+++ b/latex/tex/thesis.tex
@@ -1,6 +1,7 @@
 %% !TeX program = lualatex
 
 %\listfiles
+\newcommand{\readinfomarkerone}
 % **************************
 % STOP - Bitte zuerst lesen, bevor Sie weitermachen
 %
@@ -10,7 +11,7 @@
 % 1. Sprache
 % Das Template unterstützt Deutsch und Englisch, Standard ist Deutsch.
 % Wenn Sie Englisch verwenden wollen, ändern Sie bitte direkt am Anfang
-% dieser Datei den Eintrag
+% der 'docinfo.tex' Datei den Eintrag
 %    \newcommand{\hsmasprache}{de}
 % auf
 %    \newcommand{\hsmasprache}{en}
@@ -72,8 +73,9 @@
 % Geben Sie allerdings digital ab, sollten Sie die Datei unterschrift.png in dem
 % Ordner /bilder durch einen Scan Ihrer eigenen Unteschrift ersetzen - andernfalls
 % unterschreiben Sie als Max Mustermann ;-)
+\newcommand{\changesignaturemarker}
 % *******************************************************************
-
+\newcommand{\readinfomarkertwo}
 
 % Dokumenteneinstellungen und Infos importieren
 \input{docinfo}


### PR DESCRIPTION
Added a bash script that checks the Latex on defined rules.

- Rules are defined in a `rules.json` file
- A guide on how to use is added in the `readme.md`
- Rules are to be defined with regex for `grep`
- Example rules are given
- made adjustments to default values in Latex
- corrected a mistake in the docs